### PR TITLE
Build configuration. Set default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 Automatically unsubscribe from emails in Rails. 
 
 ## Usage
-TODO
+```ruby
+Unsubscribe.setup do |config|
+  # Must be an array of Mailer Classes
+  config.mailers = ["MarketingMailer"]
+
+  # Must be :opt_in or :opt_out
+  config.subscription_strategy = :opt_in
+end
+```
 
 ## Installation
 Add this line to your application's Gemfile:

--- a/lib/unsubscribe.rb
+++ b/lib/unsubscribe.rb
@@ -8,6 +8,7 @@ module Unsubscribe
   # https://guides.rubyonrails.org/engines.html#configuring-an-engine
 
   # TODO: Raise an exception if this is not an array
+  # TODO: Raise an exception if the Mailer does not exist
   # raise Unsubscribe::Error "mailers should be an array" unless Unsubscribe.mailers.class == Array
   mattr_accessor :mailers
   @@mailers = []

--- a/lib/unsubscribe.rb
+++ b/lib/unsubscribe.rb
@@ -6,6 +6,13 @@ module Unsubscribe
   end
 
   # https://guides.rubyonrails.org/engines.html#configuring-an-engine
+
+  # TODO: Raise an exception if this is not an array
+  # raise Unsubscribe::Error "mailers should be an array" unless Unsubscribe.mailers.class == Array
   mattr_accessor :mailers
   @@mailers = []
+  
+  # TODO: Raise an exception value is anything other than :opt_in or :opt_out
+  mattr_accessor :subscription_strategy
+  @@subscription_strategy = :opt_out
 end

--- a/lib/unsubscribe.rb
+++ b/lib/unsubscribe.rb
@@ -2,5 +2,10 @@ require "unsubscribe/version"
 require "unsubscribe/engine"
 
 module Unsubscribe
-  # Your code goes here...
+  class Error < StandardError
+  end
+
+  # https://guides.rubyonrails.org/engines.html#configuring-an-engine
+  mattr_accessor :mailers
+  @@mailers = []
 end

--- a/lib/unsubscribe.rb
+++ b/lib/unsubscribe.rb
@@ -15,4 +15,8 @@ module Unsubscribe
   # TODO: Raise an exception value is anything other than :opt_in or :opt_out
   mattr_accessor :subscription_strategy
   @@subscription_strategy = :opt_out
+
+  def self.setup
+    yield self
+  end
 end

--- a/test/dummy/config/initializers/unsubscribe.rb
+++ b/test/dummy/config/initializers/unsubscribe.rb
@@ -1,0 +1,3 @@
+Unsubscribe.setup do |config|
+  config.mailers = ["MarketingMailer"]
+end

--- a/test/unsubscribe_test.rb
+++ b/test/unsubscribe_test.rb
@@ -5,6 +5,10 @@ class UnsubscribeTest < ActiveSupport::TestCase
     assert Unsubscribe::VERSION
   end
 
+  test "default mailers is an empty array" do
+    assert_equal [], Unsubscribe.mailers
+  end
+
   test "can set mailers" do
     assert Unsubscribe.respond_to?(:mailers)
     assert Unsubscribe.respond_to?(:mailers=)

--- a/test/unsubscribe_test.rb
+++ b/test/unsubscribe_test.rb
@@ -14,9 +14,13 @@ class UnsubscribeTest < ActiveSupport::TestCase
     assert Unsubscribe.respond_to?(:mailers=)
   end
 
-  test "mailer should be an array" do
-    assert_raises(Unsubscribe::Error) do
-      Unsubscribe.mailers= "some_string"
-    end
+  test "default subscription_strategy is opt_out" do
+    assert_equal [], Unsubscribe.mailers
   end
+
+  test "can set subscription_strategy" do
+    assert Unsubscribe.respond_to?(:subscription_strategy)
+    assert Unsubscribe.respond_to?(:subscription_strategy=)
+  end  
+
 end

--- a/test/unsubscribe_test.rb
+++ b/test/unsubscribe_test.rb
@@ -21,6 +21,10 @@ class UnsubscribeTest < ActiveSupport::TestCase
   test "can set subscription_strategy" do
     assert Unsubscribe.respond_to?(:subscription_strategy)
     assert Unsubscribe.respond_to?(:subscription_strategy=)
-  end  
+  end
+
+  test "can be configured" do
+    assert Unsubscribe.respond_to?(:setup)
+  end
 
 end

--- a/test/unsubscribe_test.rb
+++ b/test/unsubscribe_test.rb
@@ -4,4 +4,15 @@ class UnsubscribeTest < ActiveSupport::TestCase
   test "it has a version number" do
     assert Unsubscribe::VERSION
   end
+
+  test "can set mailers" do
+    assert Unsubscribe.respond_to?(:mailers)
+    assert Unsubscribe.respond_to?(:mailers=)
+  end
+
+  test "mailer should be an array" do
+    assert_raises(Unsubscribe::Error) do
+      Unsubscribe.mailers= "some_string"
+    end
+  end
 end


### PR DESCRIPTION
I'm still exploring how this gem should be able to be configured, and I think I'll keep it like this for now. The API should allow someone to set what [Mailers](https://guides.rubyonrails.org/action_mailer_basics.html) someone can unsubscribe/subscribe from. We'll also want the API to allow the subscription strategy to be set. In other words, will users automatically be subscribed to mailers, or will they need to opt-in first?

```ruby
Unsubscribe.setup do |config|
  # Must be an array of Mailer Classes
  config.mailers = ["MarketingMailer"]

  # Must be :opt_in or :opt_out
  config.subscription_strategy = :opt_in
end