### PR TITLE
Fix long index ArgumentError

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,2 +1,3 @@
 ignore:
   - 'test/dummy/**/*'
+  - 'db/migrate/*'

--- a/db/migrate/20210918092925_create_unsubscribe_mailer_subscriptions.rb
+++ b/db/migrate/20210918092925_create_unsubscribe_mailer_subscriptions.rb
@@ -2,7 +2,7 @@ class CreateUnsubscribeMailerSubscriptions < ActiveRecord::Migration[6.0]
   def change
     create_table :unsubscribe_mailer_subscriptions do |t|
       # Needs to be polymorphic to be flexible. Owner may not always be a User.
-      t.references :owner, polymorphic: true, null: false, index: { name: "owner_index" }
+      t.references :owner, polymorphic: true, null: false, index: { name: "unsubscribe_owner_index" }
       t.boolean :subscribed
       t.string :mailer, null: false
 
@@ -10,6 +10,6 @@ class CreateUnsubscribeMailerSubscriptions < ActiveRecord::Migration[6.0]
     end
 
     # An owner should only have one Unsubscribe::MailerSubscription record per Mailer.
-    add_index :unsubscribe_mailer_subscriptions, [:owner_id, :owner_type, :mailer], unique: true, name: "unsubscribe_owner_index"
+    add_index :unsubscribe_mailer_subscriptions, [:owner_id, :owner_type, :mailer], unique: true, name: "unsubscribe_owner_mailer_index"
   end
 end

--- a/db/migrate/20210918092925_create_unsubscribe_mailer_subscriptions.rb
+++ b/db/migrate/20210918092925_create_unsubscribe_mailer_subscriptions.rb
@@ -2,7 +2,7 @@ class CreateUnsubscribeMailerSubscriptions < ActiveRecord::Migration[6.0]
   def change
     create_table :unsubscribe_mailer_subscriptions do |t|
       # Needs to be polymorphic to be flexible. Owner may not always be a User.
-      t.references :owner, polymorphic: true, null: false
+      t.references :owner, polymorphic: true, null: false, index: { name: "owner_index" }
       t.boolean :subscribed
       t.string :mailer, null: false
 
@@ -10,6 +10,6 @@ class CreateUnsubscribeMailerSubscriptions < ActiveRecord::Migration[6.0]
     end
 
     # An owner should only have one Unsubscribe::MailerSubscription record per Mailer.
-    add_index :unsubscribe_mailer_subscriptions, [:owner_id, :owner_type, :mailer], unique: true, name: :unsubscribe_owner_index
+    add_index :unsubscribe_mailer_subscriptions, [:owner_id, :owner_type, :mailer], unique: true, name: "unsubscribe_owner_index"
   end
 end


### PR DESCRIPTION
Name index to fix 

```
ArgumentError: Index name 'index_unsubscribe_mailer_subscriptions_on_owner_type_and_owner_id' on table 'unsubscribe_mailer_subscriptions' is too long; the limit is 64 characters
```